### PR TITLE
Skim the list of muons to accept only TRK && GLB muons in the endcaps

### DIFF
--- a/src/TTreeGenerator.cc
+++ b/src/TTreeGenerator.cc
@@ -755,12 +755,18 @@ void TTreeGenerator::fill_muon_variables(edm::Handle<reco::MuonCollection>  muLi
 
     if(imuons >= recoMuSize_) break;
 
+    bool isTrackerArb = muon::isGoodMuon((*nmuon), muon::TrackerMuonArbitrated);
+
+    if (nmuon->pt()            < 5.0 && 
+	std::abs(nmuon->eta()) > 1.4 &&
+	!isTrackerArb)
+      continue;
+
     Mu_isMuGlobal.push_back(nmuon->isGlobalMuon()); 
     Mu_isMuTracker.push_back(nmuon->isTrackerMuon());
     Mu_isMuStandAlone.push_back(nmuon->isStandAloneMuon());
     Mu_isMuRPC.push_back(nmuon->isRPCMuon());
     
-    bool isTrackerArb = muon::isGoodMuon((*nmuon), muon::TrackerMuonArbitrated);
     Mu_isMuTrackerArb.push_back(isTrackerArb);
 
     Mu_numberOfChambers.push_back(nmuon->numberOfChambers());

--- a/src/TTreeGenerator.cc
+++ b/src/TTreeGenerator.cc
@@ -757,9 +757,8 @@ void TTreeGenerator::fill_muon_variables(edm::Handle<reco::MuonCollection>  muLi
 
     bool isTrackerArb = muon::isGoodMuon((*nmuon), muon::TrackerMuonArbitrated);
 
-    if (nmuon->pt()            < 5.0 && 
-	std::abs(nmuon->eta()) > 1.4 &&
-	!isTrackerArb)
+    if (std::abs(nmuon->eta()) > 1.4 &&
+	!(isTrackerArb && nmuon->isGlobalMuon()))
       continue;
 
     Mu_isMuGlobal.push_back(nmuon->isGlobalMuon()); 

--- a/test/RunTree_collisions_cfg.py
+++ b/test/RunTree_collisions_cfg.py
@@ -32,7 +32,7 @@ process.load("RecoMuon.TrackingTools.MuonServiceProxy_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")  #DB v2, at least since GR_E_V42
 
-process.GlobalTag.globaltag = '92X_dataRun2_Prompt_v8'
+process.GlobalTag.globaltag = '94X_dataRun2_ReReco_EOY17_v2'
 
 # for the emulator
 process.load("L1TriggerConfig.DTTPGConfigProducers.L1DTTPGConfigFromDB_cff")
@@ -53,7 +53,7 @@ process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring
   (
 
-    '/store/express/Run2017F/ExpressPhysics/FEVT/Express-v1/000/306/121/00000/AA283EDA-C9C0-E711-9DCB-02163E0145AF.root',
+    '/store/data/Run2017F/SingleMuon/RAW-RECO/ZMu-17Nov2017-v1/00000/06FB9E1B-BEF1-E711-9122-0025905A608E.root',
 
   ),
   secondaryFileNames = cms.untracked.vstring(


### PR DESCRIPTION
Do not include in the ntuples muons in the endcap that are not TRK arbitrated and GLB: 
**std::abs(eta) > 1.4 AND NOT (isTrkArb && isGlb)**

The average number of muons in a ZMuSKim file goes from 7.14 to 2.73.